### PR TITLE
Disable dependabot on yarn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    open-pull-requests-limit: 0
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
Dependabot does not support yarn 2 yet. Waiting for dependabot/dependabot-core/issues/1297.