### PR TITLE
Use single DB for federation and internal server

### DIFF
--- a/configs/docker-compose.yml
+++ b/configs/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: "${MONGO_ADMIN_USERNAME}"
       MONGO_INITDB_ROOT_PASSWORD: "${MONGO_ADMIN_PASSWORD}"
+      MONGO_INITDB_DATABASE: unifed
 
   proxy:
     image: nginx:stable-alpine
@@ -56,7 +57,7 @@ services:
       UNIFED_SMTP_PORT: "${SMTP_PORT}"
       UNIFED_MONGO_HOSTNAME: mongo
       UNIFED_MONGO_PORT: '27017'
-      UNIFED_MONGO_DATABASE: unifed-internal
+      UNIFED_MONGO_DATABASE: unifed
       UNIFED_MONGO_USERNAME: user
       UNIFED_MONGO_PASSWORD: pass
       UNIFED_JWT_SECRET: "${JWT_SECRET}"
@@ -84,7 +85,7 @@ services:
     environment:
       UNIFED_MONGO_HOSTNAME: mongo
       UNIFED_MONGO_PORT: '27017'
-      UNIFED_MONGO_DATABASE: unifed-federation
+      UNIFED_MONGO_DATABASE: unifed
       UNIFED_MONGO_USERNAME: user
       UNIFED_MONGO_PASSWORD: pass
       UNIFED_SITE_HOST: "${SITE_HOST}"

--- a/configs/kube-deployment.yml
+++ b/configs/kube-deployment.yml
@@ -31,6 +31,8 @@ spec:
           value: ${MONGO_ADMIN_USERNAME}
         - name: MONGO_INITDB_ROOT_PASSWORD
           value: ${MONGO_ADMIN_PASSWORD}
+        - name: MONGO_INITDB_DATABASE
+          value: unifed
     
     - name: nginx
       image: docker.io/corfr/nginx-dnsmasq
@@ -85,7 +87,7 @@ spec:
         - name: UNIFED_MONGO_PORT
           value: 27017
         - name: UNIFED_MONGO_DATABASE
-          value: unifed-internal
+          value: unifed
         - name: UNIFED_MONGO_USERNAME
           value: user
         - name: UNIFED_MONGO_PASSWORD
@@ -122,7 +124,7 @@ spec:
         - name: UNIFED_MONGO_PORT
           value: 27017
         - name: UNIFED_MONGO_DATABASE
-          value: unifed-federation
+          value: unifed
         - name: UNIFED_MONGO_USERNAME
           value: user
         - name: UNIFED_MONGO_PASSWORD

--- a/configs/mongo-dev.js
+++ b/configs/mongo-dev.js
@@ -2,7 +2,7 @@
  * CS3099 Group A3
  */
 
-db = db.getSiblingDB("unifed-internal");
+db = db.getSiblingDB("unifed");
 
 db.users.insert({
   _id: "45bc8036-0af7-403b-a174-34dbf735c038",

--- a/configs/mongo-init.js
+++ b/configs/mongo-init.js
@@ -2,20 +2,14 @@
  * CS3099 Group A3
  */
 
-const databaseNames = ["unifed-internal", "unifed-federation"];
-
-databaseNames.forEach((name) => {
-  db.getSiblingDB(name).createUser({
-    user: "user",
-    pwd: "pass",
-    roles:[{
-      role: "readWrite",
-      db: name
-    }]
-  });
+db.createUser({
+  user: "user",
+  pwd: "pass",
+  roles:[{
+    role: "readWrite",
+    db: "unifed"
+  }]
 });
-
-db = db.getSiblingDB("unifed-federation");
 
 db.communities.insert({
   _id: "all",


### PR DESCRIPTION
In a previous PR, we started using separate DBs for the federation server and internal server. The intention was to separate them and do everything through the federation protocol.

However, there are clearly instances now where the federation protocol does not support things that we need, and it is more hassle than it is worth to keep them separated.

This PR moves back to a single DB.