### PR TITLE
Fix bug in the header's `SearchInput`

### DIFF
--- a/packages/frontend/src/components/App/Header/SearchInput.tsx
+++ b/packages/frontend/src/components/App/Header/SearchInput.tsx
@@ -114,6 +114,7 @@ export function SearchInput(): ReactElement {
 
   if (selectedCommunity) {
     history.push(`/instances/${selectedCommunity.host}/communities/${selectedCommunity.id}/posts`);
+    setSelectedCommunity(null);
   }
 
   return (


### PR DESCRIPTION
Before this, when a user searched for and navigated to a community, clicking onto the search bar again in the future caused the user to be redirected to that community again.