### PR TITLE
Fix video calling on Safari

### DIFF
--- a/packages/frontend/src/pages/CommunityCallPage/safe-peer-connection.ts
+++ b/packages/frontend/src/pages/CommunityCallPage/safe-peer-connection.ts
@@ -67,7 +67,10 @@ export class SafePeerConnection {
     const connected = this.super.iceConnectionState === "connected";
 
     // If the frame rate is greater than 0 then the video is ready.
-    const videoReady = videoTracks && videoTracks[0].getSettings().frameRate;
+    //
+    // On Safari, frameRate is undefined, so the strict equality check
+    // with 0 is essential.
+    const videoReady = videoTracks && videoTracks[0].getSettings().frameRate !== 0;
 
     return !!(connected && (videoTracks === undefined || videoReady));
   }


### PR DESCRIPTION
`getSettings()` has `frameRate` is set to undefined on Safari. This prevents the video from loading.